### PR TITLE
Alignment macros now use the offsetof macro to avoid casting pointers to integers in the C++ generator

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2020-06-07  Ivan de Jesus Deras  <ideras@gmail.com>
+
+	* etc/cpp_skel.cc gen_cpp.c: Alignment macros now use 'offsetof'
+	to avoid casting pointers to integers in the C++ generator.
+
+	* tests/output*.out: Update test output files after 'offsetof'
+	changes.
+
 2020-06-06  Ivan de Jesus Deras  <ideras@gmail.com>
 
 	* etc/cpp_skel.cc, etc/cpp_gc_skel.cc, gen_cpp.c: make the filename

--- a/etc/cpp_skel.cc
+++ b/etc/cpp_skel.cc
@@ -58,7 +58,7 @@ YYNODESTATE *YYNODESTATE::state__ = 0;
 		type field; \
 	}
 #define	YYNODESTATE_ALIGN_FOR_TYPE(type)	\
-	((unsigned)(unsigned long)(&(((struct _YYNODESTATE_align_##type *)0)->field)))
+	offsetof(_YYNODESTATE_align_##type, field)
 #define	YYNODESTATE_ALIGN_MAX(a,b)	\
 	((a) > (b) ? (a) : (b))
 #define	YYNODESTATE_ALIGN_MAX3(a,b,c) \

--- a/gen_cpp.c
+++ b/gen_cpp.c
@@ -1012,6 +1012,11 @@ static void WriteCPPHeaders(TreeCCContext *context)
 		{
 			TreeCCStreamSourceTop(stream);
 			TreeCCStreamPrint(stream, "\n");
+			if(!context->use_gc_allocator)
+			{
+				TreeCCStreamPrint(stream, "#include <cstddef>\n");
+				TreeCCStreamPrint(stream, "\n");
+			}
 		}
 		if(context->namespace)
 		{

--- a/tests/output5.out
+++ b/tests/output5.out
@@ -320,6 +320,8 @@ protected:
 #endif
 /* output.c.  Generated automatically by treecc */
 
+#include <cstddef>
+
 #define YYNODESTATE_REENTRANT 1
 #define YYNODESTATE_TRACK_LINES 1
 #define YYNODESTATE_USE_ALLOCATOR 1
@@ -384,7 +386,7 @@ YYNODESTATE *YYNODESTATE::state__ = 0;
 		type field; \
 	}
 #define	YYNODESTATE_ALIGN_FOR_TYPE(type)	\
-	((unsigned)(unsigned long)(&(((struct _YYNODESTATE_align_##type *)0)->field)))
+	offsetof(_YYNODESTATE_align_##type, field)
 #define	YYNODESTATE_ALIGN_MAX(a,b)	\
 	((a) > (b) ? (a) : (b))
 #define	YYNODESTATE_ALIGN_MAX3(a,b,c) \
@@ -598,7 +600,7 @@ long YYNODESTATE::currLinenum() const
 }
 
 #endif
-#line 282 "output.c"
+#line 284 "output.c"
 intnum *YYNODESTATE::intnumCreate(int num)
 {
 	void *buf__ = this->alloc(sizeof(intnum));
@@ -706,7 +708,7 @@ void binary::infer_type()
 		type = int_type;
 	}
 }
-#line 390 "output.c"
+#line 392 "output.c"
 
 int binary::isA(int kind) const
 {
@@ -739,7 +741,7 @@ void unary::infer_type()
 	expr->infer_type();
 	type = expr->type;
 }
-#line 423 "output.c"
+#line 425 "output.c"
 
 int unary::isA(int kind) const
 {
@@ -771,7 +773,7 @@ void intnum::infer_type()
 {
 	type = int_type;
 }
-#line 455 "output.c"
+#line 457 "output.c"
 
 int intnum::isA(int kind) const
 {
@@ -906,7 +908,7 @@ void power::infer_type()
 
 	type = expr1->type;
 }
-#line 590 "output.c"
+#line 592 "output.c"
 
 int power::isA(int kind) const
 {

--- a/tests/output6.out
+++ b/tests/output6.out
@@ -300,6 +300,8 @@ void infer_type(expression * e);
 #endif
 /* output.c.  Generated automatically by treecc */
 
+#include <cstddef>
+
 #define YYNODESTATE_TRACK_LINES 1
 #define YYNODESTATE_USE_ALLOCATOR 1
 #line 1 "cpp_skel.cc"
@@ -363,7 +365,7 @@ YYNODESTATE *YYNODESTATE::state__ = 0;
 		type field; \
 	}
 #define	YYNODESTATE_ALIGN_FOR_TYPE(type)	\
-	((unsigned)(unsigned long)(&(((struct _YYNODESTATE_align_##type *)0)->field)))
+	offsetof(_YYNODESTATE_align_##type, field)
 #define	YYNODESTATE_ALIGN_MAX(a,b)	\
 	((a) > (b) ? (a) : (b))
 #define	YYNODESTATE_ALIGN_MAX3(a,b,c) \
@@ -577,7 +579,7 @@ long YYNODESTATE::currLinenum() const
 }
 
 #endif
-#line 281 "output.c"
+#line 283 "output.c"
 void *expression::operator new(size_t size__)
 {
 	return YYNODESTATE::getState()->alloc(size__);
@@ -852,7 +854,7 @@ void infer_type(expression * e__)
 			
 				e->type = e->expr1->type;
 			}
-#line 556 "output.c"
+#line 558 "output.c"
 		}
 		break;
 
@@ -882,7 +884,7 @@ void infer_type(expression * e__)
 					e->type = int_type;
 				}
 			}
-#line 586 "output.c"
+#line 588 "output.c"
 		}
 		break;
 
@@ -895,7 +897,7 @@ void infer_type(expression * e__)
 				infer_type(e->expr);
 				e->type = e->expr->type;
 			}
-#line 599 "output.c"
+#line 601 "output.c"
 		}
 		break;
 
@@ -906,7 +908,7 @@ void infer_type(expression * e__)
 			{
 				e->type = int_type;
 			}
-#line 610 "output.c"
+#line 612 "output.c"
 		}
 		break;
 

--- a/tests/output9.out
+++ b/tests/output9.out
@@ -306,6 +306,8 @@ public:
 #endif
 /* output.c.  Generated automatically by treecc */
 
+#include <cstddef>
+
 #define YYNODESTATE_TRACK_LINES 1
 #define YYNODESTATE_USE_ALLOCATOR 1
 #line 1 "cpp_skel.cc"
@@ -369,7 +371,7 @@ YYNODESTATE *YYNODESTATE::state__ = 0;
 		type field; \
 	}
 #define	YYNODESTATE_ALIGN_FOR_TYPE(type)	\
-	((unsigned)(unsigned long)(&(((struct _YYNODESTATE_align_##type *)0)->field)))
+	offsetof(_YYNODESTATE_align_##type, field)
 #define	YYNODESTATE_ALIGN_MAX(a,b)	\
 	((a) > (b) ? (a) : (b))
 #define	YYNODESTATE_ALIGN_MAX3(a,b,c) \
@@ -583,7 +585,7 @@ long YYNODESTATE::currLinenum() const
 }
 
 #endif
-#line 281 "output.c"
+#line 283 "output.c"
 void *expression::operator new(size_t size__)
 {
 	return YYNODESTATE::getState()->alloc(size__);
@@ -858,7 +860,7 @@ void Infer::infer_type(expression * e__)
 			
 				e->type = e->expr1->type;
 			}
-#line 556 "output.c"
+#line 558 "output.c"
 		}
 		break;
 
@@ -888,7 +890,7 @@ void Infer::infer_type(expression * e__)
 					e->type = int_type;
 				}
 			}
-#line 586 "output.c"
+#line 588 "output.c"
 		}
 		break;
 
@@ -901,7 +903,7 @@ void Infer::infer_type(expression * e__)
 				infer_type(e->expr);
 				e->type = e->expr->type;
 			}
-#line 599 "output.c"
+#line 601 "output.c"
 		}
 		break;
 
@@ -912,7 +914,7 @@ void Infer::infer_type(expression * e__)
 			{
 				e->type = int_type;
 			}
-#line 610 "output.c"
+#line 612 "output.c"
 		}
 		break;
 


### PR DESCRIPTION
The current solution of casting pointers to **unsigned long** give problems when compiling for Windows 64, because sizeof long is 4 (MINGW and MSVS at least).Using the standard macro **offsetof** avoid this problem.
The **cstddef** include file cannot go into the cpp skeleton file because it gives problems when using namespaces.